### PR TITLE
Add buffer processing, Add support for multiple timestamped MIDI messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@ Is not meant to support any kind of GUI.
 
 - [x] Host fx plugins (audio in, audio out)
 - [x] Set parameters
-- [ ] Host midi instrumenst (midi in, audio out)
-
-I could not get midi going.
-You can see me trying in lib.rs
+- [x] Host midi instruments (midi in, audio out)
 
 ```rust
 // set up a host with max 1000 plugins and a buffer length of 1

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -10,32 +10,56 @@ fn main() {
     println!("I didn't crash!");
 }
 
+struct Host {
+    host: Lv2Host,
+    #[allow(dead_code)]
+    host_map: Pin<Box<HostMap<HashURIDMapper>>>,
+//    features: Vec<*const lv2_raw::core::LV2Feature>,
+//    pub features_ptr: *const *const lv2_raw::core::LV2Feature,
+    map_interface: lv2_sys::LV2_URID_Map,
+//    mapfp: *const lv2_raw::core::LV2Feature,
+//    mapf: lv2_raw::core::LV2Feature,
+}
+
+impl Host {
+    pub fn new() -> Self {
+        let mut host = Lv2Host::new(1000, 1, 44100);
+        let mut host_map: Pin<Box<HostMap<HashURIDMapper>>> = Box::pin(HashURIDMapper::new().into());
+        let mut map_interface = host_map.as_mut().make_map_interface();
+        let map = LV2Map::new(&map_interface);
+        host.set_maps(&map);
+        // let map_ptr = map_interface.handle;
+        host.printmap();
+        Self {
+            host,
+            host_map,
+//            features,
+//            features_ptr,
+            map_interface,
+//            mapfp,
+//            mapf,
+        }
+    }
+}
+
 // doesn't work yet
 fn audio_midi_instrument_test(){
-    let mut host = Lv2Host::new(1000, 1, 44100);
-    let mut host_map: Pin<Box<HostMap<HashURIDMapper>>> = Box::pin(HashURIDMapper::new().into());
-    let mut map_interface = host_map.as_mut().make_map_interface();
-    let map = LV2Map::new(&map_interface);
-    let midi_type_urid = map.map_str("http://lv2plug.in/ns/ext/midi#MidiEvent").unwrap();
-    let atom_seq_urid = map.map_str("http://lv2plug.in/ns/ext/atom#Sequence").unwrap();
-    let bytes = midi_type_urid.get().to_le_bytes();
-    println!("{}, {:?}", midi_type_urid.get(), bytes);
-    // let map_ptr = map_interface.handle;
+    let mut old_host = Host::new();
+//    println!("{}", old_host.features_ptr as usize);
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    let mut host = Host::new();
+//    println!("{}", host.features_ptr as usize);
     let mapf = lv2_raw::core::LV2Feature {
         uri: LV2_URID_MAP.as_ptr() as *const i8,
-        data: &mut map_interface as *mut lv2_sys::LV2_URID_Map as *mut std::ffi::c_void,
+        data: &mut host.map_interface as *mut lv2_sys::LV2_URID_Map as *mut std::ffi::c_void,
     };
     let mapfp = &mapf as *const lv2_raw::core::LV2Feature;
     let features = vec![mapfp, std::ptr::null::<lv2_raw::core::LV2Feature>()];
     let features_ptr = features.as_ptr() as *const *const lv2_raw::core::LV2Feature;
-    host.add_plugin("http://calf.sourceforge.net/plugins/Monosynth", "Organ".to_owned(), features_ptr).expect("Lv2hm: could not add plugin");
-    host.set_value("Organ", "MIDI Channel", 0.0);
-
-    // set up atom bytestreams
-    let asbytes = atom_seq_urid.get().to_le_bytes();
-    let midi_on = test_midi_atom(bytes, asbytes, [0x90, 50, 100]);
-    let midi_off = test_midi_atom(bytes, asbytes, [0x80, 50, 100]);
-    let reset = [8,0,0,0, asbytes[0], asbytes[1], asbytes[2], asbytes[3], 0,0,0,0,0,0,0,0,];
+//    host.host.add_plugin("http://drobilla.net/plugins/mda/Piano", "Organ".to_owned(), host.features_ptr).expect("Lv2hm: could not add plugin");
+//    host.host.add_plugin("http://calf.sourceforge.net/plugins/Monosynth", "Organ".to_owned(), host.features_ptr).expect("Lv2hm: could not add plugin");
+    host.host.add_plugin("https://github.com/RustAudio/rust-lv2/tree/master/docs/amp", "Organ".to_owned(), features_ptr).expect("Lv2hm: could not add plugin");
+    host.host.set_value("Organ", "MIDI Channel", 0.0);
 
     let spec = hound::WavSpec {
         channels: 2,
@@ -43,19 +67,22 @@ fn audio_midi_instrument_test(){
         bits_per_sample: 16,
         sample_format: hound::SampleFormat::Int,
     };
+//    println!("{}", old_host.features_ptr as usize);
+//    println!("{}", host.features_ptr as usize);
     let mut writer = hound::WavWriter::create("outp.wav", spec).unwrap();
     for i in 0..44100 {
-	    // alternate midi on and off messages, 5000 samples apart
+        // alternate midi on and off messages, 5000 samples apart
         let bytes = if (i % 10000) == 0 {
-            &midi_on[..]
+            Some([0x90, 74, 96])
         }
         else if (i % 5000) == 0 {
-            &midi_off[..]
+            Some([0x80, 74, 96])
         }
         else {
-            &reset
+            None
         };
-        let (l, r) = host.apply_instrument(0, bytes);
+    //    let bytes = Some([0x90, 74, 96]);
+        let (l, r) = host.host.apply_midi(0, bytes, (0.0, 0.0));
         let amplitude = i16::MAX as f32;
         writer.write_sample((l * amplitude) as i16).unwrap();
         writer.write_sample((r * amplitude) as i16).unwrap();
@@ -98,26 +125,4 @@ fn audio_process_test(){
         writer.write_sample((r * i16::MAX.abs() as f32) as i16)
             .expect("Error: could not write sample");
     }
-}
-
-fn test_midi_atom(typebytes: [u8; 4], seqbytes: [u8; 4], midibytes: [u8; 3]) -> [u8;38]{
-    [
-        // size
-        32, 0, 0, 0,
-        // type
-        seqbytes[0], seqbytes[1], seqbytes[2], seqbytes[3],
-        // timestamp
-        0,0,0,0,0,0,0,0, // frame
-        0,0,0,0,0,0,0,0, // subframe
-        // size
-        3, 0, 0, 0,
-        // type
-        typebytes[0], typebytes[1], typebytes[2], typebytes[3],
-        // midi
-        midibytes[0],
-        midibytes[1],
-        midibytes[2],
-        // 32 bit pad (not sure if this is necessary)
-        0,0,0,
-    ]
 }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,65 +1,16 @@
 use lv2hm::*;
 
-use urid::*;
-use lv2_urid::*;
-use std::pin::Pin;
-
 fn main() {
     audio_midi_instrument_test();
-    //audio_process_test();
+    audio_process_test();
     println!("I didn't crash!");
 }
 
-struct Host {
-    host: Lv2Host,
-    #[allow(dead_code)]
-    host_map: Pin<Box<HostMap<HashURIDMapper>>>,
-//    features: Vec<*const lv2_raw::core::LV2Feature>,
-//    pub features_ptr: *const *const lv2_raw::core::LV2Feature,
-    map_interface: lv2_sys::LV2_URID_Map,
-//    mapfp: *const lv2_raw::core::LV2Feature,
-//    mapf: lv2_raw::core::LV2Feature,
-}
-
-impl Host {
-    pub fn new() -> Self {
-        let mut host = Lv2Host::new(1000, 1, 44100);
-        let mut host_map: Pin<Box<HostMap<HashURIDMapper>>> = Box::pin(HashURIDMapper::new().into());
-        let mut map_interface = host_map.as_mut().make_map_interface();
-        let map = LV2Map::new(&map_interface);
-        host.set_maps(&map);
-        // let map_ptr = map_interface.handle;
-        host.printmap();
-        Self {
-            host,
-            host_map,
-//            features,
-//            features_ptr,
-            map_interface,
-//            mapfp,
-//            mapf,
-        }
-    }
-}
-
-// doesn't work yet
 fn audio_midi_instrument_test(){
-    let mut old_host = Host::new();
 //    println!("{}", old_host.features_ptr as usize);
-    std::thread::sleep(std::time::Duration::from_secs(1));
-    let mut host = Host::new();
-//    println!("{}", host.features_ptr as usize);
-    let mapf = lv2_raw::core::LV2Feature {
-        uri: LV2_URID_MAP.as_ptr() as *const i8,
-        data: &mut host.map_interface as *mut lv2_sys::LV2_URID_Map as *mut std::ffi::c_void,
-    };
-    let mapfp = &mapf as *const lv2_raw::core::LV2Feature;
-    let features = vec![mapfp, std::ptr::null::<lv2_raw::core::LV2Feature>()];
-    let features_ptr = features.as_ptr() as *const *const lv2_raw::core::LV2Feature;
-//    host.host.add_plugin("http://drobilla.net/plugins/mda/Piano", "Organ".to_owned(), host.features_ptr).expect("Lv2hm: could not add plugin");
-//    host.host.add_plugin("http://calf.sourceforge.net/plugins/Monosynth", "Organ".to_owned(), host.features_ptr).expect("Lv2hm: could not add plugin");
-    host.host.add_plugin("https://github.com/RustAudio/rust-lv2/tree/master/docs/amp", "Organ".to_owned(), features_ptr).expect("Lv2hm: could not add plugin");
-    host.host.set_value("Organ", "MIDI Channel", 0.0);
+    let mut host = Lv2Host::new(1, 1, 44100);
+    host.add_plugin("http://calf.sourceforge.net/plugins/Monosynth", "Organ".to_owned()).expect("Lv2hm: could not add plugin");
+    host.set_value("Organ", "MIDI Channel", 0.0);
 
     let spec = hound::WavSpec {
         channels: 2,
@@ -69,41 +20,41 @@ fn audio_midi_instrument_test(){
     };
 //    println!("{}", old_host.features_ptr as usize);
 //    println!("{}", host.features_ptr as usize);
-    let mut writer = hound::WavWriter::create("outp.wav", spec).unwrap();
+    let mut writer = hound::WavWriter::create("midi-outp.wav", spec).unwrap();
     for i in 0..44100 {
         // alternate midi on and off messages, 5000 samples apart
-        let bytes = if (i % 10000) == 0 {
-            Some([0x90, 74, 96])
+        let mut midimsg = Vec::new();
+        if (i % 10000) == 0 {
+            midimsg.push((0, [0x90, 72, 96]))
         }
         else if (i % 5000) == 0 {
-            Some([0x80, 74, 96])
+            midimsg.push((0, [0x80, 72, 96]))
         }
-        else {
-            None
-        };
-    //    let bytes = Some([0x90, 74, 96]);
-        let (l, r) = host.host.apply_midi(0, bytes, (0.0, 0.0));
+        let out = host.process(0, midimsg, [&[0.0], &[0.0]]).unwrap();
         let amplitude = i16::MAX as f32;
-        writer.write_sample((l * amplitude) as i16).unwrap();
-        writer.write_sample((r * amplitude) as i16).unwrap();
+        writer.write_sample((out[0][0] * amplitude) as i16).unwrap();
+        writer.write_sample((out[1][0] * amplitude) as i16).unwrap();
     }
 }
 
 fn audio_process_test(){
     let mut host = Lv2Host::new(1000, 1, 44100);
-    host.add_plugin("http://calf.sourceforge.net/plugins/Reverb", "reverb".to_owned(), std::ptr::null_mut()).expect("Lv2hm: could not add plugin");
-    host.add_plugin("http://calf.sourceforge.net/plugins/VintageDelay", "delay".to_owned(), std::ptr::null_mut()).expect("Lv2hm: could not add plugin");
-    host.add_plugin("http://calf.sourceforge.net/plugins/Compressor", "compressor".to_owned(), std::ptr::null_mut()).expect("Lv2hm: could not add plugin");
-    host.add_plugin("http://calf.sourceforge.net/plugins/Crusher", "crusher".to_owned(), std::ptr::null_mut()).expect("Lv2hm: could not add plugin");
+    host.add_plugin("http://calf.sourceforge.net/plugins/Reverb", "reverb".to_owned()).expect("Lv2hm: could not add plugin");
+    host.add_plugin("http://calf.sourceforge.net/plugins/VintageDelay", "delay".to_owned()).expect("Lv2hm: could not add plugin");
+    host.add_plugin("http://calf.sourceforge.net/plugins/Compressor", "compressor".to_owned()).expect("Lv2hm: could not add plugin");
+    host.add_plugin("http://calf.sourceforge.net/plugins/Crusher", "crusher".to_owned()).expect("Lv2hm: could not add plugin");
     // host.remove_plugin("reverb");
     // host.remove_plugin("delay");
-    println!("{:?}", host.get_plugin_sheet(0));
 
     let args: Vec<String> = std::env::args().collect();
+    if args.len() <= 1 {
+	    println!("expected an input file argument for audio test");
+	    return
+    }
     let file = &args[1];
     let mut reader = hound::WavReader::open(file).expect("Lv2hm: could not open audio file.");
     let specs = reader.spec();
-    let mut writer = hound::WavWriter::create("outp.wav", specs).unwrap();
+    let mut writer = hound::WavWriter::create("audio-outp.wav", specs).unwrap();
 
     let mut iter = reader.samples::<i16>();
     loop{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,11 +35,11 @@ pub struct Lv2Host{
     atom_buf: Pin<Box<[u8; 1024]>>,
     atom_urid_bytes: [u8; 4],
     midi_urid_bytes: [u8; 4],
-	#[allow(dead_code)]
-	host_map: Pin<Box<HostMap<HashURIDMapper>>>,
-	pub map_interface: lv2_sys::LV2_URID_Map,
-//	feature_vec: Pin<Vec<lv2_raw::core::LV2Feature>>,
-//	features: Pin<Vec<*const lv2_raw::core::LV2Feature>>,
+    #[allow(dead_code)]
+    host_map: Pin<Box<HostMap<HashURIDMapper>>>,
+    pub map_interface: lv2_sys::LV2_URID_Map,
+//    feature_vec: Pin<Vec<lv2_raw::core::LV2Feature>>,
+//    features: Pin<Vec<*const lv2_raw::core::LV2Feature>>,
 }
 
 #[derive(Debug)]
@@ -55,12 +55,12 @@ pub enum AddPluginError{
 
 impl Lv2Host{
     pub fn new(plugin_cap: usize, buffer_len: usize, sample_rate: usize) -> Self{
-	    // setup feature map
-		let mut host_map: Pin<Box<HostMap<HashURIDMapper>>> = Box::pin(HashURIDMapper::new().into());
-		let map_interface = host_map.as_mut().make_map_interface();
-		let map = LV2Map::new(&map_interface);
-	    let midi_urid_bytes = map.map_str("http://lv2plug.in/ns/ext/midi#MidiEvent").unwrap().get().to_le_bytes();
-	    let atom_urid_bytes = map.map_str("http://lv2plug.in/ns/ext/atom#Sequence").unwrap().get().to_le_bytes();
+        // setup feature map
+        let mut host_map: Pin<Box<HostMap<HashURIDMapper>>> = Box::pin(HashURIDMapper::new().into());
+        let map_interface = host_map.as_mut().make_map_interface();
+        let map = LV2Map::new(&map_interface);
+        let midi_urid_bytes = map.map_str("http://lv2plug.in/ns/ext/midi#MidiEvent").unwrap().get().to_le_bytes();
+        let atom_urid_bytes = map.map_str("http://lv2plug.in/ns/ext/atom#Sequence").unwrap().get().to_le_bytes();
 
         let (world, lilv_plugins) = unsafe{
             let world = lilv_world_new();
@@ -96,14 +96,14 @@ impl Lv2Host{
 
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn add_plugin(&mut self, uri: &str, name: String) -> Result<usize, AddPluginError>{
-		let feature_vec = vec![lv2_raw::core::LV2Feature {
-			uri: LV2_URID_MAP.as_ptr() as *const i8,
-			data: &mut self.map_interface as *mut lv2_sys::LV2_URID_Map as *mut std::ffi::c_void,
-		}];
-		let mapfp = feature_vec.as_ptr() as *const lv2_raw::core::LV2Feature;
-		let features = vec![mapfp, std::ptr::null::<lv2_raw::core::LV2Feature>()];
+        let feature_vec = vec![lv2_raw::core::LV2Feature {
+            uri: LV2_URID_MAP.as_ptr() as *const i8,
+            data: &mut self.map_interface as *mut lv2_sys::LV2_URID_Map as *mut std::ffi::c_void,
+        }];
+        let mapfp = feature_vec.as_ptr() as *const lv2_raw::core::LV2Feature;
+        let features = vec![mapfp, std::ptr::null::<lv2_raw::core::LV2Feature>()];
 
-		let features_ptr = features.as_ptr() as *const *const lv2_raw::core::LV2Feature;
+        let features_ptr = features.as_ptr() as *const *const lv2_raw::core::LV2Feature;
         let replace_index = self.dead_list.pop();
         if self.plugins.len() == self.plugin_cap && replace_index == None{
             return Err(AddPluginError::CapacityReached);
@@ -146,10 +146,10 @@ impl Lv2Host{
                     },
                     PortType::Audio => {
                         if p.is_input {
-                            lilv_instance_connect_port(instance, p.index, self.in_buf.as_ptr().offset(i) as *mut ffi::c_void);
+                            lilv_instance_connect_port(instance, p.index, self.in_buf.as_ptr().offset(i*self.buffer_len as isize) as *mut ffi::c_void);
                             i += 1;
                         } else {
-                            lilv_instance_connect_port(instance, p.index, self.out_buf.as_ptr().offset(o) as *mut ffi::c_void);
+                            lilv_instance_connect_port(instance, p.index, self.out_buf.as_ptr().offset(o*self.buffer_len as isize) as *mut ffi::c_void);
                             o += 1;
                         }
                     },
@@ -262,47 +262,8 @@ impl Lv2Host{
         (self.out_buf[0], self.out_buf[1])
     }
 
-    // TODO: fix
-    // pub fn _apply_plugin_n_frames(&mut self, index: usize, input: &[f32]) -> Option<&[f32]>{
-    //     let frames = input.len() / 2;
-    //     if frames > self.buffer_len { return None; }
-    //     if index >= self.plugins.len() { return None; }
-    //     for (i, v) in input.iter().enumerate(){
-    //         self.in_buf[i] = *v;
-    //     }
-    //     let plugin = &mut self.plugins[index];
-    //     unsafe{
-    //         lilv_instance_run(plugin.instance, frames as u32);
-    //     }
-    //     Some(&self.out_buf)
-    // }
-
-    pub fn apply_instrument(&mut self, index: usize, input: &[u8]) -> (f32, f32){
-        if index >= self.plugins.len() { return (0.0, 0.0); }
-        for (i, v) in input.iter().enumerate() {
-            self.atom_buf[i] = *v;
-        }
-        let plugin = &mut self.plugins[index];
-        unsafe {
-            lilv_instance_run(plugin.instance, 1);
-        }
-        (self.out_buf[0], self.out_buf[1])
-    }
-
-    pub fn apply_midi(&mut self, index: usize, input: Option<[u8; 3]>, input_frame: (f32, f32)) -> (f32, f32) {
-	    if let Some(inner) = input {
-	    	let buffer = test_midi_atom(self.midi_urid_bytes, self.atom_urid_bytes, inner);
-		//    println!("lv2hm midi: {:?}", buffer);
-	        for (i, v) in buffer.iter().enumerate() {
-	            self.atom_buf[i] = *v;
-	        }
-	    }
-	    else {
-		    let buffer = [8,0,0,0, self.atom_urid_bytes[0], self.atom_urid_bytes[1], self.atom_urid_bytes[2], self.atom_urid_bytes[3], 0,0,0,0,0,0,0,0,];
-	        for (i, v) in buffer.iter().enumerate() {
-	            self.atom_buf[i] = *v;
-	        }
-	    };
+    pub fn apply_midi(&mut self, index: usize, input: [u8; 3], input_frame: (f32, f32)) -> (f32, f32) {
+        test_midi_atom(self.midi_urid_bytes, self.atom_urid_bytes, vec![(0,input)], &mut self.atom_buf);
         if index >= self.plugins.len() { panic!() }
         self.in_buf[0] = input_frame.0;
         self.in_buf[1] = input_frame.1;
@@ -312,28 +273,58 @@ impl Lv2Host{
         }
         (self.out_buf[0], self.out_buf[1])
     }
+
+    pub fn process(&mut self, index: usize, input: Vec<(u64, [u8; 3])>, input_frame: [&[f32]; 2]) -> Result<[&[f32]; 2], ()>{
+        test_midi_atom(self.midi_urid_bytes, self.atom_urid_bytes, input, &mut self.atom_buf);
+        if index >= self.plugins.len() { return Err(()); }
+        let frames = input_frame[0].len();
+        if frames != input_frame[1].len() || frames > self.buffer_len {
+            return Err(());
+        }
+        for (i, (l, r)) in input_frame[0].iter().zip(input_frame[1].iter()).enumerate(){
+            self.in_buf[i] = *l;
+            self.in_buf[i+self.buffer_len] = *r;
+        }
+        let plugin = &mut self.plugins[index];
+        unsafe{
+            lilv_instance_run(plugin.instance, frames as u32);
+        }
+        Ok([&self.out_buf[..frames], &self.out_buf[self.buffer_len..][..frames]])
+    }
 }
 
-fn test_midi_atom(typebytes: [u8; 4], seqbytes: [u8; 4], midibytes: [u8; 3]) -> [u8;38]{
-    [
-        // size
-        32, 0, 0, 0,
-        // type
-        seqbytes[0], seqbytes[1], seqbytes[2], seqbytes[3],
+fn test_midi_atom(typebytes: [u8; 4], seqbytes: [u8; 4], midibytes: Vec<(u64, [u8; 3])>, atom_buf: &mut [u8; 1024]) {
+    // size gets written at the end
+    //self.atom_buf[0..4] = [8,0,0,0];
+    let mut pos = 4; // current offset
+    // type
+    copy_bytes(atom_buf, &seqbytes, &mut pos); // type: sequence
+    copy_bytes(atom_buf, &[0,0,0,0,0,0,0,0,], &mut pos); // frame
+
+    for (ea_time, ea_midi) in midibytes {
         // timestamp
-        0,0,0,0,0,0,0,0, // frame
-        0,0,0,0,0,0,0,0, // subframe
-        // size
-        3, 0, 0, 0,
-        // type
-        typebytes[0], typebytes[1], typebytes[2], typebytes[3],
-        // midi
-        midibytes[0],
-        midibytes[1],
-        midibytes[2],
-        // 32 bit pad (not sure if this is necessary)
-        0,0,0,
-    ]
+        copy_bytes(atom_buf, &ea_time.to_le_bytes(), &mut pos); // subframe
+
+        copy_bytes(atom_buf, &3_u32.to_le_bytes(), &mut pos); // size
+        copy_bytes(atom_buf, &typebytes, &mut pos); // type: midi
+        copy_bytes(atom_buf, &ea_midi, &mut pos);
+        let extra = 8 - (pos % 8);
+        if extra != 8 {
+            for idx in 0..extra {
+                atom_buf[pos..][idx] = 0;
+            }
+            pos += extra;
+        }
+    }
+    pos -= 8; // length shouldn't include size and type of top-level atom
+    copy_bytes(atom_buf, &(pos as u32).to_le_bytes(), &mut 0); // size
+}
+
+fn copy_bytes(to: &mut [u8], from: &[u8], at: &mut usize) {
+    for (to, from) in to[*at..].iter_mut().zip(from.iter()) {
+        *to = *from;
+    }
+    *at += from.len();
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ impl Lv2Host{
     }
 
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn add_plugin(&mut self, uri: &str, name: String) -> Result<(), AddPluginError>{
+    pub fn add_plugin(&mut self, uri: &str, name: String) -> Result<usize, AddPluginError>{
 		let feature_vec = vec![lv2_raw::core::LV2Feature {
 			uri: LV2_URID_MAP.as_ptr() as *const i8,
 			data: &mut self.map_interface as *mut lv2_sys::LV2_URID_Map as *mut std::ffi::c_void,
@@ -180,7 +180,7 @@ impl Lv2Host{
             self.plugin_names.insert(name, self.plugins.len() - 1);
         }
 
-        Ok(())
+        Ok(self.plugins.len() - 1)
     }
 
     pub fn remove_plugin(&mut self, name: &str) -> bool{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub struct Lv2Host{
     sr: f64,
     in_buf: Vec<f32>,
     out_buf: Vec<f32>,
-    atom_buf: Pin<Box<[u8; 1024]>>,
+    atom_buf: [u8; 1024],
     atom_urid_bytes: [u8; 4],
     midi_urid_bytes: [u8; 4],
     #[allow(dead_code)]
@@ -80,7 +80,7 @@ impl Lv2Host{
             sr: sample_rate as f64,
             in_buf: vec![0.0; buffer_len * 2], // also don't let it resize
             out_buf: vec![0.0; buffer_len * 2], // also don't let it resize
-            atom_buf: Box::pin([0; 1024]),
+            atom_buf: [0; 1024],
             atom_urid_bytes,
             midi_urid_bytes,
             host_map,


### PR DESCRIPTION
Made a few changes to the API that I think makes a version bump technically necessary. I also combined the buffer processed audio and MIDI functions into one, which can just be called with an empty `midimsg` Vec for audio processing. I left the single-sample processing functions alone, but it might be a good idea to combine those too just for consistency?

I think the thing that was preventing buffer processing from working before was the port buffer offset assignments. Instead of incrementing by the buffer size, the offsets for each port were just incremented by one, so the left and right buffers would be mostly overlapping (except for one sample).

Looking forward to hearing what you think