### PR TITLE
Use lv2-atom for MIDI Atom handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,19 @@ path = "src/bin.rs"
 [dependencies]
 lilv-sys = "0.2.1"
 lv2_raw = "0.2.0"
-lv2-urid = "2.1.0"
-lv2-sys = "2.0.0"
-urid = "0.1.0"
 hound = "3.4.0"
+
+lv2-atom = { git = "https://github.com/RustAudio/rust-lv2", branch = "develop" , default-features = false }
+lv2-midi = { git = "https://github.com/RustAudio/rust-lv2", branch = "develop" }
+lv2-urid = { git = "https://github.com/RustAudio/rust-lv2", branch = "develop" }
+lv2-sys = { git = "https://github.com/RustAudio/rust-lv2", branch = "develop" }
+urid = { git = "https://github.com/RustAudio/rust-lv2", branch = "develop", default-features = false }
+
+[patch.crates-io]
+lv2-atom = { git = "https://github.com/RustAudio/rust-lv2", branch = "develop" }
+lv2-midi = { git = "https://github.com/RustAudio/rust-lv2", branch = "develop" }
+lv2-units = { git = "https://github.com/RustAudio/rust-lv2", branch = "develop" }
+lv2-urid = { git = "https://github.com/RustAudio/rust-lv2", branch = "develop" }
+lv2-core = { git = "https://github.com/RustAudio/rust-lv2", branch = "develop" }
+lv2-sys = { git = "https://github.com/RustAudio/rust-lv2", branch = "develop" }
+urid = { git = "https://github.com/RustAudio/rust-lv2", branch = "develop" }


### PR DESCRIPTION
This PR adds a dependency on `lv2-atom` to allow to safely write MIDI events to the plugin's Atom buffer.

As of right now, the version of `lv2-atom` that has the ability to seamlessly integrate into non-plugin project isn't released yet on crates.io, therefore the Cargo.toml has to be rather heavily patched to point to the project's GitHub instead.

Other than that issue, this PR is changing the following:

* Replaced the Atom Buffer implementation from an inline byte array to a boxed [`AlignedSpace`](https://github.com/RustAudio/rust-lv2/blob/develop/atom/src/space/aligned.rs) (`AtomSpace` being a type alias for `AlignedSpace<AtomHeader>`), which is a zero-cost wrapper around `[u8]` which enforces proper alignment of the written atom data.
  * Atom data must be properly aligned when written (the LV2 spec specifies a 64-bit alignement for Atom Headers), otherwise hosted plugins will perform unaligned reads. While this is ok-ish on x86 (it's just much slower), this is UB on other architectures.
  * The boxed `AlignedSpace` is created through an [`AlignedVec`](https://github.com/RustAudio/rust-lv2/blob/develop/atom/src/space/vec.rs#L8) to help creating an aligned heap-allocated buffer, and then turned into a boxed slice to ensure it never gets reallocated.
  * I took that same pattern of using `Vec::into_boxed_slice` for audio buffers, to statically ensure they never resize and get reallocated as well.
* Replaced the URID's byte array representation with fully typed URIDs. Besides being clearer, this allows the `lv2-atom` APIs to easily expose the API associated for writing the requested Atom type.
* Added the `AtomWriteError` error type to the enum of possible errors. Atom writing is always a fallible operation (mostly if it runs out of space in the underlying buffer), so all Atom-writing APIs return this error in a `Result`.
* Re-implemented `midi_into_atom_buffer` with the `lv2-atom` APIs, which now does the following:
  * Create a cursor for writing data into the buffer (similar to the `pos` offset that was there before).
  * Start writing an atom of the given type, `URID<Sequence>` which, after configuring it with a specified sequence timestamp type, gives us a [`SequenceWriter`](https://github.com/RustAudio/rust-lv2/blob/develop/atom/src/atoms/sequence.rs) that wraps the previously created cursor and allows us to append events to the buffer. It also keeps track of the global atom size automatically every time an event is appended.
  * For each MIDI event, add a new timestamped Sequence Event, which again receives a typed `URID` to return the associated writer type. Here for simple MIDI a raw byte buffer writer is returned, which allows to write raw byte slices, but a writer that integrates with `wmidi` is also available if desired.