### PR TITLE
apply_multi take a slice for input

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -28,7 +28,7 @@ fn audio_midi_instrument_test(){
         else if (i % 5000) == 0 {
             midimsg.push((0, [0x80, 72, 96]))
         }
-        let out = host.apply_multi(0, midimsg, [&[0.0], &[0.0]]).unwrap();
+        let out = host.apply_multi(0, &midimsg, [&[0.0], &[0.0]]).unwrap();
         let amplitude = i16::MAX as f32;
         writer.write_sample((out[0][0] * amplitude) as i16).unwrap();
         writer.write_sample((out[1][0] * amplitude) as i16).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,7 +323,7 @@ impl Lv2Host{
     /// of samples returned.
     ///
     /// Returns two buffers of samples, or an error.
-    pub fn apply_multi(&mut self, index: usize, input: Vec<(u64, [u8; 3])>, input_frame: [&[f32]; 2]) -> Result<[&[f32]; 2], ApplyError>{
+    pub fn apply_multi(&mut self, index: usize, input: &[(u64, [u8; 3])], input_frame: [&[f32]; 2]) -> Result<[&[f32]; 2], ApplyError>{
         midi_into_atom_buffer(self.seq_urid, self.midi_urid, &input, &mut self.atom_buf)
             .map_err(ApplyError::AtomWriteError)?;
 


### PR DESCRIPTION
`apply_multi()` should take a slice for the `input` instead of forcing a move.

This actually fix some valgrind issues complaining about memory on the stack.